### PR TITLE
fix: prevent toolbar overflow — ensure render engine toggle visible

### DIFF
--- a/frontend/carousel-generator-preview.html
+++ b/frontend/carousel-generator-preview.html
@@ -600,7 +600,7 @@
 <body class="h-screen overflow-hidden flex flex-col font-sans">
 
     <!-- Top Configuration Header -->
-    <header class="h-16 glass-panel flex items-center justify-between px-6 shrink-0 z-20 relative">
+    <header class="min-h-[64px] glass-panel flex items-center justify-between px-4 md:px-6 shrink-0 z-20 relative">
         <div class="flex items-center gap-4">
             <div
                 class="w-8 h-8 rounded-xl bg-gradient-to-br from-primary to-secondary flex items-center justify-center shadow-[0_0_15px_rgba(139,92,246,0.5)]">
@@ -616,9 +616,9 @@
             </div>
         </div>
 
-        <div class="flex items-center gap-5">
+        <div class="flex items-center gap-3 flex-wrap">
             <!-- Mode Toggle -->
-            <div class="glass-panel p-1 rounded-lg flex gap-1 border border-glass h-9">
+            <div class="glass-panel p-1 rounded-lg flex gap-1 border border-glass h-9 shrink-0">
                 <button onclick="setMode('split')" id="btn-split"
                     class="px-3 py-1 rounded text-[11px] font-medium text-white bg-white/10 transition-all flex items-center gap-1.5 pointer">
                     <i data-lucide="layout-panel-left" class="w-3.5 h-3.5"></i> Split
@@ -630,7 +630,7 @@
             </div>
 
             <!-- Render Engine Toggle -->
-            <div class="glass-panel p-1 rounded-lg flex gap-1 border border-glass h-9">
+            <div class="glass-panel p-1 rounded-lg flex gap-1 border border-glass h-9 shrink-0">
                 <button onclick="setRenderEngine('classic')" id="btn-engine-classic"
                     class="px-3 py-1 rounded text-[11px] font-medium text-white bg-white/10 transition-all flex items-center gap-1.5 pointer">
                     Classic


### PR DESCRIPTION
- Changed header from fixed h-16 to min-h-[64px] for flexibility
- Reduced toolbar gap from gap-5 to gap-3
- Added flex-wrap to prevent buttons from being hidden on overflow
- Added shrink-0 to toggle groups so they don't collapse

https://claude.ai/code/session_01QdSyAifwnwKYJjpA2KtgRJ