### PR TITLE
feat: Configure AI Compose, fix icons, add shortcuts, fix templates

### DIFF
--- a/frontend/carousel-generator-preview.html
+++ b/frontend/carousel-generator-preview.html
@@ -892,7 +892,7 @@
                                 <i data-lucide="refresh-cw" class="w-3 h-3"></i> Refresh
                             </button>
                         </div>
-                        <div id="template-gallery-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 min-h-[60px]">
+                        <div id="template-gallery-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 min-h-[60px] max-h-[320px] overflow-y-auto scrollbar-thin">
                             <!-- Populated by JS -->
                             <div id="template-gallery-empty" class="col-span-full text-center py-6">
                                 <p class="text-[11px] text-gray-500">Belum ada template tersimpan. Upload gambar referensi di Smart Extractor untuk membuat template.</p>
@@ -3157,6 +3157,8 @@
                     return true;
                 }
                 if (window._carouselToast) window._carouselToast('Template berhasil disimpan!');
+                // Auto-refresh template gallery
+                if (typeof window._loadTemplateGallery === 'function') window._loadTemplateGallery();
                 return true;
             } catch (e) {
                 console.error('saveTemplateToDB:', e);
@@ -3165,6 +3167,8 @@
                 saved.push(template);
                 localStorage.setItem('jadisatu_carousel_templates', JSON.stringify(saved));
                 if (window._carouselToast) window._carouselToast('Template disimpan ke local storage.');
+                // Auto-refresh template gallery
+                if (typeof window._loadTemplateGallery === 'function') window._loadTemplateGallery();
                 return true;
             }
         }
@@ -3191,6 +3195,7 @@
                         });
                         if (res.error) throw res.error;
                         console.log('[TemplateFolders] Saved folder to Supabase');
+                        if (typeof window._loadTemplateGallery === 'function') window._loadTemplateGallery();
                         return true;
                     } catch (e) {
                         console.warn('[TemplateFolders] Supabase save failed, falling back to localStorage:', e);
@@ -3205,6 +3210,7 @@
                     if (local.length > 20) local = local.slice(0, 20);
                     localStorage.setItem('jadisatu_template_folders', JSON.stringify(local));
                     console.log('[TemplateFolders] Saved folder to localStorage');
+                    if (typeof window._loadTemplateGallery === 'function') window._loadTemplateGallery();
                     return true;
                 } catch (e) {
                     console.warn('[TemplateFolders] localStorage save failed:', e);
@@ -4694,7 +4700,7 @@
                             .select('id, name, template_data, created_at')
                             .eq('user_id', currentUserId)
                             .order('created_at', { ascending: false })
-                            .limit(12);
+                            .limit(6);
                         if (res.data && res.data.length > 0) {
                             templates = res.data;
                         }
@@ -4707,7 +4713,7 @@
                             .select('id, name, shared_brand, styles, source, created_at')
                             .eq('user_id', currentUserId)
                             .order('created_at', { ascending: false })
-                            .limit(12);
+                            .limit(4);
                         if (fRes.data && fRes.data.length > 0) {
                             folders = fRes.data;
                         }
@@ -4731,7 +4737,7 @@
                 // Clear grid
                 grid.innerHTML = '';
 
-                if (templates.length === 0) {
+                if (templates.length === 0 && folders.length === 0) {
                     grid.innerHTML = '<div id="template-gallery-empty" class="col-span-full text-center py-6"><p class="text-[11px] text-gray-500">Belum ada template tersimpan. Upload gambar di Smart Extractor.</p></div>';
                     return;
                 }

--- a/frontend/js/fabric-renderer.js
+++ b/frontend/js/fabric-renderer.js
@@ -97,35 +97,83 @@ var FabricRenderer = (function() {
         return obj;
     }
 
+    // ─── Convert kebab-case to PascalCase ─────────────
+    // Lucide stores icons as PascalCase keys (e.g., "Sparkles", "ArrowRight")
+    // but composition data uses kebab-case (e.g., "sparkles", "arrow-right")
+    function kebabToPascal(str) {
+        return str.split('-').map(function(part) {
+            return part.charAt(0).toUpperCase() + part.slice(1);
+        }).join('');
+    }
+
+    // ─── Build SVG children from Lucide node array ──────
+    function buildSvgChildren(nodes) {
+        var html = '';
+        if (!Array.isArray(nodes)) return html;
+        nodes.forEach(function(node) {
+            if (!Array.isArray(node) || node.length < 2) return;
+            var tag = node[0];
+            var attrs = node[1] || {};
+            html += '<' + tag;
+            Object.keys(attrs).forEach(function(k) {
+                html += ' ' + k + '="' + attrs[k] + '"';
+            });
+            html += '/>';
+        });
+        return html;
+    }
+
     // ─── Get Lucide SVG path ────────────────────────────
     function getLucideSvg(iconName, size, color) {
-        if (typeof lucide !== 'undefined' && lucide.icons && lucide.icons[iconName]) {
-            var iconData = lucide.icons[iconName];
-            var svgStr = '<svg xmlns="http://www.w3.org/2000/svg" width="' + size + '" height="' + size + '" viewBox="0 0 24 24" fill="none" stroke="' + color + '" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
-            if (Array.isArray(iconData)) {
-                iconData.forEach(function(node) {
-                    if (Array.isArray(node) && node.length >= 2) {
-                        var tag = node[0];
-                        var attrs = node[1];
-                        svgStr += '<' + tag;
-                        Object.keys(attrs).forEach(function(k) {
-                            svgStr += ' ' + k + '="' + attrs[k] + '"';
-                        });
-                        svgStr += '/>';
+        if (typeof lucide === 'undefined') return '';
+
+        // Try to find icon in lucide.icons (PascalCase keys)
+        var icons = lucide.icons;
+        var iconData = null;
+
+        if (icons) {
+            // Try PascalCase lookup first (e.g., "sparkles" → "Sparkles")
+            var pascalName = kebabToPascal(iconName);
+            iconData = icons[pascalName] || icons[iconName] || icons[iconName.toLowerCase()];
+
+            // Fallback: scan all icon keys case-insensitively
+            if (!iconData) {
+                var lowerName = iconName.toLowerCase().replace(/-/g, '');
+                var allKeys = Object.keys(icons);
+                for (var i = 0; i < allKeys.length; i++) {
+                    if (allKeys[i].toLowerCase() === lowerName) {
+                        iconData = icons[allKeys[i]];
+                        break;
                     }
-                });
+                }
             }
+        }
+
+        if (iconData && Array.isArray(iconData)) {
+            var svgStr = '<svg xmlns="http://www.w3.org/2000/svg" width="' + size + '" height="' + size + '" viewBox="0 0 24 24" fill="none" stroke="' + color + '" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
+
+            // Lucide format: ["svg", {attrs}, [children]] — children at index 2
+            // Or legacy format: flat array of [tag, attrs] pairs
+            if (iconData.length === 3 && iconData[0] === 'svg' && Array.isArray(iconData[2])) {
+                // New Lucide format: ["svg", {svgAttrs}, [[tag, attrs], ...]]
+                svgStr += buildSvgChildren(iconData[2]);
+            } else {
+                // Legacy/flat format: [[tag, attrs], [tag, attrs], ...]
+                svgStr += buildSvgChildren(iconData);
+            }
+
             svgStr += '</svg>';
             return svgStr;
         }
 
+        // Fallback: use DOM-based rendering via lucide.createIcons
         var tempDiv = document.createElement('div');
         tempDiv.style.cssText = 'position:absolute;left:-9999px;top:-9999px;';
         tempDiv.innerHTML = '<i data-lucide="' + iconName + '"></i>';
         document.body.appendChild(tempDiv);
 
-        if (typeof lucide !== 'undefined' && lucide.createIcons) {
-            lucide.createIcons({ root: tempDiv });
+        if (lucide.createIcons) {
+            try { lucide.createIcons({ root: tempDiv }); } catch (e) { }
         }
 
         var svg = tempDiv.querySelector('svg');
@@ -593,6 +641,14 @@ var FabricRenderer = (function() {
             }
             return;
         }
+        // Cut: Ctrl+X (copy then delete)
+        if (ctrl && e.key === 'x') {
+            if (active && !active._isBackground) {
+                e.preventDefault();
+                cutSelected();
+            }
+            return;
+        }
         // Paste: Ctrl+V
         if (ctrl && e.key === 'v') {
             e.preventDefault();
@@ -823,6 +879,14 @@ var FabricRenderer = (function() {
         active.clone(function(cloned) {
             _clipboard = cloned;
         }, ['_elementType', '_iconName']);
+    }
+
+    function cutSelected() {
+        if (!_canvas) return;
+        var active = _canvas.getActiveObject();
+        if (!active || active._isBackground) return;
+        copySelected();
+        deleteSelected();
     }
 
     function pasteClipboard() {
@@ -1100,6 +1164,7 @@ var FabricRenderer = (function() {
         // CRUD: Manipulate
         deleteSelected: deleteSelected,
         copySelected: copySelected,
+        cutSelected: cutSelected,
         pasteClipboard: pasteClipboard,
         duplicateSelected: duplicateSelected,
         selectAll: selectAll,

--- a/hunter-agent/backend/api.py
+++ b/hunter-agent/backend/api.py
@@ -338,7 +338,10 @@ Return JSON with this structure:
 Create 5-8 slides. Last slide should be CTA. Return ONLY valid JSON."""
 
     try:
-        response = model.generate_content(prompt)
+        response = model.generate_content(
+            contents=prompt,
+            generation_config={"temperature": 0.7, "max_output_tokens": 8192}
+        )
         raw = response.text.strip()
         if raw.startswith("```json"):
             raw = raw[7:]
@@ -730,9 +733,8 @@ async def compose_slides(req: ComposeRequest):
 
     import google.generativeai as genai
     genai.configure(api_key=gemini_key)
-    model = genai.GenerativeModel("gemini-2.5-flash")
 
-    # Parse canvas dimensions
+    # Parse canvas dimensions (needed for system instruction)
     try:
         cw, ch = req.canvas_size.split("x")
         canvas_w, canvas_h = int(cw), int(ch)
@@ -755,77 +757,91 @@ DESIGN DNA:
 
     slides_json = json.dumps(req.slides, ensure_ascii=False, indent=2)
 
-    prompt = f"""Kamu adalah AI Visual Composer untuk carousel sosial media.
-Canvas: {canvas_w}x{canvas_h} pixels.
-Template preset: {req.template_preset or 'minimal-dark'}
+    # ── System instruction: expert visual composer ──
+    system_instruction = f"""Kamu adalah SENIOR VISUAL DESIGNER AI untuk carousel sosial media profesional.
+Kamu merancang layout pixel-perfect yang siap render di Fabric.js canvas.
 
-{design_ctx}
+PRINSIP DESAIN:
+- Whitespace adalah elemen desain — jangan penuhi canvas
+- Hierarki visual yang jelas: mata pembaca mengalir dari headline → icon → body → footer
+- Konsistensi spacing: gunakan kelipatan 8px (8, 16, 24, 32, 40, 48, 64, 80)
+- Kontras warna minimal 4.5:1 untuk teks agar mudah dibaca
+- Setiap slide harus punya focal point yang jelas
+
+CANVAS: {canvas_w}x{canvas_h} pixels
+SAFE ZONE: 64px padding dari semua edge (konten di area {canvas_w - 128}x{canvas_h - 128} di tengah)"""
+
+    model = genai.GenerativeModel("gemini-2.5-flash", system_instruction=system_instruction)
+
+    prompt = f"""{design_ctx}
+
+TEMPLATE PRESET: {req.template_preset or 'minimal-dark'}
+
+TEMPLATE COLOR GUIDE:
+- "minimal-dark": bg=#0f0f11, accent=#8b5cf6 (purple), text=#ffffff, surface=rgba(255,255,255,0.04)
+- "bold-gradient": bg=#1a0533, accent=#f59e0b (amber), text=#ffffff, gradients lebih dramatis
+- "minimal-light": bg=#fafafa, accent=#3b82f6 (blue), text=#1a1a1a, clean & bright
+- "professional": bg=#0f172a, accent=#0ea5e9 (sky), text=#f1f5f9, corporate feel
+- "warm-earth": bg=#1c1917, accent=#d97706 (warm), text=#fef3c7, organic tones
+- "neon-dark": bg=#0a0a0a, accent=#22d3ee (cyan), text=#ffffff, glow effects
 
 SLIDES DATA:
 {slides_json}
 
-TUGAS: Untuk SETIAP slide, generate Composition JSON yang berisi SEMUA elemen visual dengan posisi TEPAT dalam pixel.
+TUGAS: Generate Composition JSON untuk SETIAP slide.
 
-ELEMENT TYPES yang tersedia:
-1. "gradient-bg" — Background gradient
+ELEMENT TYPES (gunakan PERSIS format ini):
+
+1. "gradient-bg" — WAJIB ada sebagai elemen pertama
    Properties: width, height, colorStops: [{{offset, color}}], direction: "to-bottom"|"to-bottom-right"|"to-right"
 
-2. "rect" — Rectangle/shape
-   Properties: left, top, width, height, fill, stroke, strokeWidth, rx, ry (rounded corners), opacity
+2. "circle" — Dekoratif glow/blur blobs
+   Properties: left, top, radius(100-250), fill: "rgba(accent, 0.06-0.12)"
 
-3. "circle" — Circle/ellipse
-   Properties: left, top, radius, fill, stroke, strokeWidth, opacity
+3. "rect" — Shapes, cards, icon backgrounds
+   Properties: left, top, width, height, fill, stroke, strokeWidth, rx, ry, opacity
 
-4. "textbox" — Text content
-   Properties: left, top, width, text, fontSize, fontWeight, fontStyle, fontFamily, fill (color), textAlign, lineHeight
+4. "textbox" — Teks (headline, body, badge, footer)
+   Properties: left, top, width(max {canvas_w - 128}), text, fontSize, fontWeight("400"-"900"), fontFamily("Inter, sans-serif"), fill, textAlign, lineHeight(1.2-1.7)
 
-5. "lucide-icon" — Icon dari Lucide
-   Properties: iconName, left, top, size, color
+5. "lucide-icon" — Icon dari Lucide (kebab-case: "sparkles", "zap", "brain", "target", dll)
+   Properties: iconName(kebab-case), left, top, size(48-96), color
 
-6. "line" — Garis dekoratif
-   Properties: x1, y1, x2, y2, stroke, strokeWidth
+6. "line" — Garis dekoratif/divider
+   Properties: x1, y1, x2, y2, stroke, strokeWidth(1-3)
 
-7. "image" — Gambar/ilustrasi (placeholder area)
-   Properties: left, top, width, height, src (URL atau "placeholder"), opacity, rx (rounded)
+7. "image" — Placeholder gambar
+   Properties: left, top, width, height, src("placeholder"), rx, opacity
 
-ATURAN DESAIN:
-1. Padding minimum dari edge: 64px
-2. Decorative elements WAJIB ada: minimal 2 blur circles + 1 accent line per slide
-3. Variasi posisi antar slide — jangan semua slide terlihat sama
-4. Hierarchy visual: headline paling besar (40-64px), body lebih kecil (20-28px)
-5. Icon dengan background shape (rounded rect atau circle di belakangnya)
-6. Footer di bottom: brand text kiri, progress dots kanan
-7. Sesuaikan posisi berdasarkan layout_type:
-   - hero-center: headline besar di tengah, tanpa body
-   - card-detail: card frame + headline + body di dalam
-   - split-visual: visual kiri 42%, text kanan 58%
-   - quote-highlight: tanda kutip dekoratif besar + teks centered
-   - list-bullets: headline atas + poin-poin list di bawah
-   - dramatic-closer: overlay gelap + teks besar centered
-   - text-heavy: headline + body panjang, tanpa visual
-8. Warna decorative elements: gunakan accent color dengan opacity rendah (0.05-0.15)
-9. Number badge (angka slide) di posisi yang sesuai layout
+ATURAN LAYOUT per layout_type:
 
-Balas HANYA JSON array (tanpa markdown fences):
-[
-  {{
-    "slide_index": 0,
-    "canvas": {{"width": {canvas_w}, "height": {canvas_h}}},
-    "elements": [
-      {{"type": "gradient-bg", "id": "bg", "width": {canvas_w}, "height": {canvas_h}, "colorStops": [...], "direction": "..."}},
-      {{"type": "circle", "id": "deco-glow-1", "left": ..., "top": ..., "radius": ..., "fill": "rgba(...)"}},
-      {{"type": "rect", "id": "icon-bg", "left": ..., "top": ..., "width": ..., "height": ..., "fill": "...", "rx": ..., "ry": ...}},
-      {{"type": "lucide-icon", "id": "icon", "iconName": "...", "left": ..., "top": ..., "size": ..., "color": "..."}},
-      {{"type": "textbox", "id": "headline", "left": ..., "top": ..., "width": ..., "text": "...", "fontSize": ..., ...}},
-      {{"type": "textbox", "id": "body", "left": ..., "top": ..., "width": ..., "text": "...", "fontSize": ..., ...}},
-      ...
-    ]
-  }}
-]
+"hero-center": Headline centered fontSize 52-64 fontWeight 800, Icon centered di atas size 80-96 dengan rect bg, Tanpa body, Accent line pendek
+"card-detail": Rect card frame surface color rx 24, Icon top-left size 64, Headline fontSize 40-48, Body fontSize 22-26
+"split-visual": Divider vertikal di 42%, Kiri icon besar/image, Kanan headline+body
+"quote-highlight": Tanda kutip dekoratif fontSize 120 opacity 0.15, Headline centered italic fontSize 44-52, Body attribution fontSize 20
+"list-bullets": Headline top fontSize 36-42, Body bullet list dengan newline "• " prefix, Icon top-left size 56-64
+"dramatic-closer": Dark overlay rect rgba(0,0,0,0.4), Headline centered fontSize 56-64 fontWeight 900, Body centered, Tanpa icon
+"text-heavy": Headline top-left fontSize 38-44, Body below fontSize 22-26 lineHeight 1.7, Tanpa icon
+
+ATURAN WAJIB:
+1. SETIAP slide: gradient-bg → decorations → content → footer
+2. Minimal 2 circle glow blobs per slide (radius 120-220, opacity 0.05-0.12)
+3. Minimal 1 accent line per slide
+4. VARIASI posisi decorations antar slide — jangan copy-paste
+5. Footer WAJIB: textbox "@jadisatu.cloud" left:80 top:{canvas_h - 70} + progress circle dots
+6. Icon WAJIB kebab-case: "sparkles", "zap", "brain", "target", "heart", "lightbulb", "rocket"
+7. Semua left/top/width/height = integer bulat. fontFamily SELALU "Inter, sans-serif"
+8. Setiap elemen WAJIB punya "id" unik (contoh: "bg", "deco-glow-1", "headline", "body", "icon-main", "footer-brand")
+
+Balas HANYA JSON array. Tanpa markdown fences. Tanpa penjelasan.
+[{{"slide_index":0,"canvas":{{"width":{canvas_w},"height":{canvas_h}}},"elements":[...]}}]
 """
 
     try:
-        response = model.generate_content(prompt)
+        response = model.generate_content(
+            contents=prompt,
+            generation_config={"temperature": 0.7, "max_output_tokens": 8192}
+        )
         raw_text = response.text.strip()
 
         # Clean markdown fences if present
@@ -836,6 +852,12 @@ Balas HANYA JSON array (tanpa markdown fences):
         compositions = json.loads(raw_text)
         if not isinstance(compositions, list):
             raise ValueError("Response is not a JSON array")
+
+        # Post-process: ensure all elements have required fields
+        for comp in compositions:
+            for el in comp.get("elements", []):
+                if "id" not in el:
+                    el["id"] = el.get("type", "el") + "-auto"
 
         return {
             "success": True,


### PR DESCRIPTION
1. AI Compose (api.py):
   - Upgraded system prompt with detailed design principles & rules
   - Added system_instruction for Gemini (separate from user prompt)
   - Added template color guide for all 6 presets
   - Added per-layout composition rules (hero-center, card-detail, etc)
   - Added generation_config (temperature 0.7, max_output_tokens 8192)
   - Post-process: auto-fill missing element IDs

2. Lucide Icons Fix (fabric-renderer.js):
   - Fixed PascalCase lookup (Lucide stores "Sparkles" not "sparkles")
   - Added kebabToPascal converter for icon name resolution
   - Handle both new format ["svg", attrs, children] and legacy format
   - Case-insensitive fallback scan for robustness
   - DOM-based fallback with error handling

3. Global Shortcuts (fabric-renderer.js):
   - Added Ctrl+X / Cmd+X: Cut (copy + delete)
   - Existing: Ctrl+C, Ctrl+V, Ctrl+D, Ctrl+A, Ctrl+Z, Ctrl+Y, arrows

4. Saved Templates Fix (carousel-generator-preview.html):
   - Auto-refresh gallery after template save (DB and localStorage)
   - Auto-refresh after folder save (DB and localStorage)
   - Reduced query limits (templates: 6, folders: 4) to prevent overflow
   - Added max-height 320px + overflow scroll to gallery grid
   - Fixed empty check to consider both templates AND folders

https://claude.ai/code/session_01QdSyAifwnwKYJjpA2KtgRJ