### PR TITLE
fix: Wire Content Studio to production — nginx proxy, Creative Hub li…

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,6 +15,7 @@ NGINX_ROOT="/var/www/jadisatu.cloud/public"
 DEPLOY_LOG="/var/log/jadisatu-deploy.log"
 NEXTJS_DIR="${REPO_DIR}/nextjs-app"
 HUNTER_DIR="${REPO_DIR}/hunter-agent/backend"
+VISUAL_DIR="${REPO_DIR}/visual-engine"
 
 # ── Load NVM ──────────────────────────────────────────────────
 export NVM_DIR="/root/.nvm"
@@ -68,10 +69,17 @@ else
   log "WARNING: Frontend or Nginx root missing, skipping"
 fi
 
-# ── 4. Python deps ───────────────────────────────────────────
+# ── 4. Python deps (Hunter Agent) ────────────────────────────
 cd "$HUNTER_DIR"
-pip install -r requirements.txt --quiet --break-system-packages 2>&1 | tail -3 || log "WARNING: pip install had issues"
-log "Python deps updated"
+pip install -r requirements.txt --quiet --break-system-packages 2>&1 | tail -3 || log "WARNING: pip install (hunter) had issues"
+log "Python deps updated (hunter-agent)"
+
+# ── 4b. Python deps (Visual Engine) ─────────────────────────
+cd "$VISUAL_DIR"
+pip install -r requirements.txt --quiet --break-system-packages 2>&1 | tail -3 || log "WARNING: pip install (visual-engine) had issues"
+# Ensure Playwright Chromium is installed for screenshot rendering
+python -m playwright install chromium 2>&1 | tail -3 || log "WARNING: Playwright install had issues"
+log "Python deps updated (visual-engine)"
 
 # ── 5. PM2: reload all processes ─────────────────────────────
 cd "$REPO_DIR"
@@ -84,7 +92,11 @@ else
   log "PM2 processes started (first run)"
 fi
 
-# ── 6. Nginx: test & reload ──────────────────────────────────
+# ── 6. Nginx: add visual-engine proxy if needed ──────────────
+cd "$REPO_DIR"
+bash deploy/setup-nginx-visual-engine.sh 2>&1 || log "WARNING: nginx visual-engine setup had issues"
+
+# ── 6b. Nginx: test & reload ─────────────────────────────────
 nginx -t 2>&1 || fail "Nginx config test failed"
 nginx -s reload 2>&1
 log "Nginx reloaded"
@@ -107,6 +119,12 @@ if curl -sf http://localhost:8000/api/health > /dev/null 2>&1; then
   log "Health: Extractor API OK (/api/health)"
 else
   log "WARNING: Extractor API health check failed (/api/health)"
+fi
+
+if curl -sf http://localhost:8100/api/visual/health > /dev/null 2>&1; then
+  log "Health: Visual Engine OK (port 8100)"
+else
+  log "WARNING: Visual Engine health check failed (port 8100)"
 fi
 
 # ── 8. Summary ────────────────────────────────────────────────

--- a/deploy/setup-nginx-visual-engine.sh
+++ b/deploy/setup-nginx-visual-engine.sh
@@ -1,0 +1,55 @@
+# Visual Engine proxy — add to /etc/nginx/sites-available/jadisatu.cloud
+# Place this BEFORE the general /api/ location block
+#
+# location /api/visual/ {
+#     proxy_pass http://127.0.0.1:8100;
+#     proxy_http_version 1.1;
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Real-IP $remote_addr;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Forwarded-Proto $scheme;
+#     proxy_read_timeout 120s;
+#     proxy_send_timeout 120s;
+#     client_max_body_size 20M;
+# }
+#
+# To install automatically, run:
+#   bash deploy/setup-nginx-visual-engine.sh
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+NGINX_CONF="/etc/nginx/sites-available/jadisatu.cloud"
+
+# Check if already configured
+if grep -q "api/visual" "$NGINX_CONF" 2>/dev/null; then
+    echo "[nginx] Visual Engine proxy already configured"
+    exit 0
+fi
+
+# Find the line with "location /api/" and insert visual engine proxy BEFORE it
+if grep -q "location /api/" "$NGINX_CONF"; then
+    sed -i '/location \/api\//i \
+    # Visual Engine API (port 8100)\
+    location /api/visual/ {\
+        proxy_pass http://127.0.0.1:8100;\
+        proxy_http_version 1.1;\
+        proxy_set_header Host $host;\
+        proxy_set_header X-Real-IP $remote_addr;\
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\
+        proxy_set_header X-Forwarded-Proto $scheme;\
+        proxy_read_timeout 120s;\
+        proxy_send_timeout 120s;\
+        client_max_body_size 20M;\
+    }\
+' "$NGINX_CONF"
+    echo "[nginx] Visual Engine proxy added before /api/ block"
+else
+    echo "[nginx] WARNING: Could not find 'location /api/' block in $NGINX_CONF"
+    echo "[nginx] Please manually add the visual engine proxy block"
+    exit 1
+fi
+
+# Test and reload
+nginx -t && nginx -s reload
+echo "[nginx] Config tested and reloaded"

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -31,6 +31,22 @@ module.exports = {
       log_date_format: "YYYY-MM-DD HH:mm:ss",
       error_file: "/root/.pm2/logs/hunter-agent-error.log",
       out_file: "/root/.pm2/logs/hunter-agent-out.log"
+    },
+    {
+      name: "visual-engine",
+      cwd: "./visual-engine",
+      script: "/usr/local/bin/uvicorn",
+      args: "api.app:app --host 0.0.0.0 --port 8100",
+      interpreter: "none",
+      env: {
+        PORT: 8100
+      },
+      instances: 1,
+      autorestart: true,
+      max_memory_restart: "256M",
+      log_date_format: "YYYY-MM-DD HH:mm:ss",
+      error_file: "/root/.pm2/logs/visual-engine-error.log",
+      out_file: "/root/.pm2/logs/visual-engine-out.log"
     }
   ]
 };

--- a/frontend/content-studio.html
+++ b/frontend/content-studio.html
@@ -166,6 +166,27 @@
         <!-- Content area -->
         <div id="studio-content" class="flex-1 overflow-y-auto custom-scroll">
 
+            <!-- Source content banner (shown when imported from Creative Hub) -->
+            <div id="source-content-banner" class="hidden mx-6 mt-4 glass rounded-xl p-4">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <div class="w-8 h-8 rounded-lg bg-personal/20 flex items-center justify-center">
+                            <i data-lucide="file-text" class="w-4 h-4 text-personal"></i>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium text-white" id="source-content-title">—</p>
+                            <p class="text-xs text-gray-400">Script dari Creative Hub — siap generate carousel</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <span id="source-content-status" class="text-[10px] px-2 py-0.5 rounded-full bg-success/20 text-success">ready</span>
+                        <button id="btn-dismiss-source" class="text-gray-500 hover:text-white transition-all">
+                            <i data-lucide="x" class="w-4 h-4"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             <!-- ====== STEP 1: Upload Reference Designs ====== -->
             <section id="step-upload" class="p-6">
                 <!-- Step indicator -->
@@ -520,11 +541,13 @@
 
     <!-- ==================== SCRIPTS ==================== -->
     <script src="js/config.js"></script>
+    <script src="js/data-service.js"></script>
+    <script src="js/creative-hub-service.js"></script>
     <script src="js/sidebar-workspace.js"></script>
     <script src="js/content-studio.js"></script>
 
     <script>
-        // Auth initialization (same pattern as creative-hub-view)
+        // Auth initialization + Creative Hub content import
         (function () {
             var SUPABASE_URL = 'https://dwpkokavxjvtrltntjtn.supabase.co';
             var SUPABASE_ANON_KEY = 'sb_publishable_T5-XcRCVYuXvukpmPSO2cw_JBcOBwD1';
@@ -556,16 +579,41 @@
 
                         // Update sidebar profile
                         var email = session.user.email || '';
-                        var name = email.split('@')[0] || 'User';
+                        var displayName = email.split('@')[0] || 'User';
+
+                        // Try UserProfileService for better name
+                        if (typeof UserProfileService !== 'undefined') {
+                            try {
+                                var profileSvc = new UserProfileService(client);
+                                var profile = await profileSvc.getProfile(session.user.id);
+                                if (profile && profile.display_name && profile.display_name.trim()) {
+                                    displayName = profile.display_name.trim();
+                                }
+                            } catch (e) { console.warn('[Content Studio] profile fetch:', e); }
+                        }
+
                         var nameEl = document.getElementById('sidebar-user-name');
                         var avatarEl = document.getElementById('sidebar-user-avatar');
-                        if (nameEl) nameEl.textContent = name;
-                        if (avatarEl) avatarEl.textContent = (name.substring(0, 2) || '—').toUpperCase();
+                        if (nameEl) nameEl.textContent = displayName;
+                        if (avatarEl) avatarEl.textContent = (displayName.substring(0, 2) || '—').toUpperCase();
+
+                        // Initialize Creative Hub Service (for importing scripts)
+                        if (typeof CreativeHubService !== 'undefined') {
+                            window.creativeHubService = new CreativeHubService(client, session.user.id);
+                        }
 
                         // Initialize Content Studio
                         if (window.ContentStudio) {
                             window.contentStudio = new ContentStudio();
                             window.contentStudio.init();
+
+                            // Check if we came from Creative Hub with a content_id
+                            var params = new URLSearchParams(window.location.search);
+                            var contentId = params.get('content_id') || sessionStorage.getItem('active_generator_id');
+                            if (contentId) {
+                                sessionStorage.removeItem('active_generator_id');
+                                await window.contentStudio.importFromCreativeHub(contentId);
+                            }
                         }
 
                     } catch (e) {

--- a/frontend/creative-hub-view.html
+++ b/frontend/creative-hub-view.html
@@ -904,7 +904,7 @@
 
                 function goToCarouselGenerator(itemId) {
                     try { sessionStorage.setItem('active_generator_id', itemId); } catch (e) { }
-                    window.location.href = 'carousel-generator-preview.html';
+                    window.location.href = 'content-studio.html?content_id=' + encodeURIComponent(itemId);
                 }
                 window._creativeAdvance = advanceContent;
                 window._creativeDelete = deleteContent;

--- a/frontend/js/content-studio.js
+++ b/frontend/js/content-studio.js
@@ -10,7 +10,9 @@
  */
 
 // ── Config ──────────────────────────────────────────────────────────────
-const VISUAL_ENGINE_URL = window.VISUAL_ENGINE_URL || 'http://localhost:8100';
+// In production, nginx proxies /api/visual/* → localhost:8100
+// So we use '' (empty = same origin) for production, or override via window.VISUAL_ENGINE_URL
+const VISUAL_ENGINE_URL = window.VISUAL_ENGINE_URL || '';
 
 // ── Utility: Toast ──────────────────────────────────────────────────────
 function toast(msg, type = 'info') {
@@ -208,6 +210,9 @@ class ContentStudio {
             };
 
             toast(`${data.template_count} template diekstrak!`, 'success');
+
+            // Save to Supabase for persistence
+            this._saveTemplateToSupabase(this.currentFolder);
 
             // Move to Step 2 after brief delay
             setTimeout(() => this._showStep('templates'), 800);
@@ -602,11 +607,43 @@ class ContentStudio {
 
         try {
             const userId = window.currentUser ? window.currentUser.id : null;
-            const resp = await fetch(`${VISUAL_ENGINE_URL}/api/visual/templates?user_id=${userId || ''}`);
-            if (!resp.ok) return;
+            let folders = [];
 
-            const data = await resp.json();
-            const folders = data.folders || [];
+            // Try Visual Engine API first
+            try {
+                const resp = await fetch(`${VISUAL_ENGINE_URL}/api/visual/templates?user_id=${userId || ''}`);
+                if (resp.ok) {
+                    const data = await resp.json();
+                    folders = data.folders || [];
+                }
+            } catch (e) {
+                console.warn('[Content Studio] Visual Engine API unavailable, trying Supabase...');
+            }
+
+            // Also load from Supabase (user_template_folders)
+            if (window.supabaseClient && userId) {
+                try {
+                    const { data: sbFolders, error } = await window.supabaseClient
+                        .from('user_template_folders')
+                        .select('*')
+                        .eq('user_id', userId)
+                        .order('created_at', { ascending: false });
+                    if (!error && sbFolders) {
+                        const existingIds = new Set(folders.map(f => f.id));
+                        for (const sf of sbFolders) {
+                            if (!existingIds.has(sf.id)) {
+                                folders.push({
+                                    id: sf.id,
+                                    name: sf.name,
+                                    template_count: (sf.styles || []).length,
+                                    source: 'supabase',
+                                    created_at: sf.created_at,
+                                });
+                            }
+                        }
+                    }
+                } catch (e) { console.warn('[Content Studio] Supabase template load:', e); }
+            }
 
             if (count) count.textContent = folders.length;
 
@@ -669,6 +706,103 @@ class ContentStudio {
             this._loadTemplateFolders();
         } catch (e) {
             toast('Gagal menghapus', 'error');
+        }
+    }
+
+    // ====================================================================
+    // Creative Hub Import
+    // ====================================================================
+
+    async importFromCreativeHub(contentId) {
+        const svc = window.creativeHubService;
+        if (!svc) { console.warn('[Content Studio] CreativeHubService not available'); return; }
+
+        try {
+            const item = await Promise.resolve(svc.getItem(contentId));
+            if (!item) { toast('Konten tidak ditemukan', 'error'); return; }
+
+            this._sourceContent = item;
+
+            // Show banner
+            const banner = document.getElementById('source-content-banner');
+            const titleEl = document.getElementById('source-content-title');
+            const statusEl = document.getElementById('source-content-status');
+            const dismissBtn = document.getElementById('btn-dismiss-source');
+
+            if (banner) banner.classList.remove('hidden');
+            if (titleEl) titleEl.textContent = item.title || item.hook_text || 'Untitled';
+            if (statusEl) statusEl.textContent = item.status || 'ready';
+            if (dismissBtn) dismissBtn.addEventListener('click', () => banner.classList.add('hidden'));
+
+            // Pre-fill generate form
+            const topicInput = document.getElementById('input-topic');
+            const hookInput = document.getElementById('input-hook');
+            const pointsInput = document.getElementById('input-points');
+            const ctaInput = document.getElementById('input-cta');
+
+            if (topicInput) topicInput.value = item.title || '';
+            if (hookInput) hookInput.value = item.hook_text || '';
+            if (ctaInput) ctaInput.value = item.cta_text || '';
+
+            // Parse value_text or full_script into points
+            if (pointsInput) {
+                let points = '';
+                if (item.full_script) {
+                    // Extract key points from full script
+                    points = item.full_script
+                        .split('\n')
+                        .filter(line => line.trim() && !line.startsWith('#'))
+                        .map(line => line.replace(/^[\-\*]\s*/, '').replace(/^\d+\.\s*/, '').trim())
+                        .filter(line => line.length > 5 && line.length < 200)
+                        .join('\n');
+                } else if (item.value_text) {
+                    points = item.value_text;
+                }
+                pointsInput.value = points;
+            }
+
+            toast(`Script "${item.title || 'content'}" dimuat dari Creative Hub`, 'success');
+            console.log('[Content Studio] imported content:', contentId, item.title);
+
+            if (typeof lucide !== 'undefined') lucide.createIcons();
+
+        } catch (e) {
+            console.error('[Content Studio] import error:', e);
+            toast('Gagal mengimpor konten', 'error');
+        }
+    }
+
+    // ====================================================================
+    // Supabase Template Save
+    // ====================================================================
+
+    async _saveTemplateToSupabase(folder) {
+        const client = window.supabaseClient;
+        const userId = window.currentUser?.id;
+        if (!client || !userId) return;
+
+        try {
+            const { error } = await client.from('user_template_folders').insert({
+                id: folder.folder_id,
+                user_id: userId,
+                name: folder.folder_name,
+                styles: folder.templates.map(t => ({
+                    name: t.name,
+                    description: t.description || '',
+                    colors: t.colors || {},
+                    html: t.html || '',
+                    preview_url: t.preview_url || null,
+                })),
+                created_at: new Date().toISOString(),
+            });
+
+            if (error) {
+                console.warn('[Content Studio] save template to Supabase:', error);
+            } else {
+                console.log('[Content Studio] template folder saved to Supabase:', folder.folder_id);
+            }
+        } catch (e) {
+            console.warn('[Content Studio] save template error:', e);
         }
     }
 

--- a/visual-engine/api/app.py
+++ b/visual-engine/api/app.py
@@ -55,8 +55,8 @@ app.add_middleware(
 OUTPUT_DIR = Path(__file__).parent.parent / "output"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-# Serve generated images
-app.mount("/output", StaticFiles(directory=str(OUTPUT_DIR)), name="output")
+# Serve generated images — mounted under /api/visual/output/ so nginx proxy covers it
+app.mount("/api/visual/output", StaticFiles(directory=str(OUTPUT_DIR)), name="output")
 
 # Initialize services
 extractor = SmartExtractorV2()
@@ -173,7 +173,7 @@ async def extract_templates(req: ExtractTemplatesRequest):
                     width=1080,
                     height=1080,
                 )
-                template["preview_url"] = f"/output/previews/{folder.id}/preview_{i}.png"
+                template["preview_url"] = f"/api/visual/output/previews/{folder.id}/preview_{i}.png"
             except Exception:
                 template["preview_url"] = None
 
@@ -236,7 +236,7 @@ async def render_slide(req: RenderSlideRequest):
 
         return RenderSlideResponse(
             success=True,
-            image_url=f"/output/renders/slide_{gen_id}.png",
+            image_url=f"/api/visual/output/renders/slide_{gen_id}.png",
             slide_data=req.slide_data,
         )
 
@@ -314,7 +314,7 @@ async def generate_carousel(req: GenerateCarouselRequest):
             slides.append({
                 "index": i,
                 "type": slide_data.get("type", "content"),
-                "image_url": f"/output/generations/{gen_id}/slide_{i}.png",
+                "image_url": f"/api/visual/output/generations/{gen_id}/slide_{i}.png",
                 "data": slide_data,
                 "template_used": selector.assignments.get(i, folder.templates[0]["name"] if folder.templates else ""),
             })


### PR DESCRIPTION
…nk, template save

Production fixes:
- VISUAL_ENGINE_URL uses relative URL (empty string) instead of localhost:8100
- Visual Engine output paths now under /api/visual/output/* for nginx proxy
- Add visual-engine to PM2 ecosystem.config.js (port 8100)
- Deploy script installs visual-engine deps + Playwright + health check
- Nginx proxy config script: /api/visual/* → localhost:8100

Creative Hub integration:
- Generate Carousel button now opens content-studio.html?content_id=xxx
- Content Studio imports data-service.js + creative-hub-service.js
- importFromCreativeHub() pre-fills topic/hook/points from script
- Source content banner shows imported content info

Template persistence:
- Templates auto-save to Supabase (user_template_folders) after extraction
- My Templates panel loads from both Visual Engine API and Supabase
- UserProfileService used for sidebar display name

https://claude.ai/code/session_01QdSyAifwnwKYJjpA2KtgRJ